### PR TITLE
Add a HttpPoller that remembers failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ bintrayPlugin=1.4
 commonsLangVersion = 3.4
 guavaVersion=18.0
 hamcrestVersion=1.3
+mockitoVersion=2.15.0
 junitVersion = 4.12
 okhttpVersion=3.3.1
 slf4jVersion=1.7.12

--- a/junit-resource-poller/build.gradle
+++ b/junit-resource-poller/build.gradle
@@ -8,4 +8,5 @@ dependencies {
     testCompile "com.google.guava:guava:${guavaVersion}"
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVersion}"
+    testCompile "org.mockito:mockito-core:${mockitoVersion}"
 }

--- a/junit-resource-poller/src/main/java/com/palantir/junit/FailureCachingHttpPollingResource.java
+++ b/junit-resource-poller/src/main/java/com/palantir/junit/FailureCachingHttpPollingResource.java
@@ -29,7 +29,7 @@ import org.junit.rules.ExternalResource;
  */
 public final class FailureCachingHttpPollingResource extends ExternalResource {
     private final HttpPollingResource poller;
-    private AtomicReference<Throwable> maybeError = new AtomicReference<>();
+    private final AtomicReference<Throwable> maybeError = new AtomicReference<>();
 
     public FailureCachingHttpPollingResource(HttpPollingResource poller) {
         this.poller = poller;
@@ -42,8 +42,9 @@ public final class FailureCachingHttpPollingResource extends ExternalResource {
             try {
                 poller.before();
             } catch (Throwable e) {
-                // we don't care which error of multiple parallel invocations is registered, so this is safe
-                maybeError.lazySet(e);
+                // we don't care which error of multiple parallel invocations is registered,
+                // so we don't need to compare-and-set
+                maybeError.set(e);
                 throw e;
             }
         } else {

--- a/junit-resource-poller/src/main/java/com/palantir/junit/FailureCachingHttpPollingResource.java
+++ b/junit-resource-poller/src/main/java/com/palantir/junit/FailureCachingHttpPollingResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.junit;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.rules.ExternalResource;
+
+/**
+ * A poller that stops after the first failure, and returns that failure repeatedly in subsequent
+ * invocations.
+ *
+ * This is useful if you want to tolerate long waits on the first invocation (to allow resources to
+ * come up), but not on subsequent ones - so that running a 100 tests when one resource will never come
+ * up doesn't take 100 times as long before failing.
+ */
+public final class FailureCachingHttpPollingResource extends ExternalResource {
+    private final HttpPollingResource poller;
+    private AtomicReference<Throwable> maybeError = new AtomicReference<>();
+
+    public FailureCachingHttpPollingResource(HttpPollingResource poller) {
+        this.poller = poller;
+    }
+
+    @Override
+    protected void before() {
+        Throwable previousError = maybeError.get();
+        if (previousError == null) {
+            try {
+                poller.before();
+            } catch (Throwable e) {
+                // we don't care which error of multiple parallel invocations is registered, so this is safe
+                maybeError.lazySet(e);
+                throw e;
+            }
+        } else {
+            throw new IllegalStateException("Failing due to previous error", previousError);
+        }
+    }
+}

--- a/junit-resource-poller/src/test/java/com/palantir/junit/FailureCachingHttpPollingResourceTest.java
+++ b/junit-resource-poller/src/test/java/com/palantir/junit/FailureCachingHttpPollingResourceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.junit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class FailureCachingHttpPollingResourceTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    @Mock
+    private HttpPollingResource delegate;
+
+    private FailureCachingHttpPollingResource resource;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        resource = new FailureCachingHttpPollingResource(delegate);
+    }
+
+    @Test
+    public void test_succeedsIfDelegateSucceeds() {
+        resource.before();
+    }
+
+    @Test
+    public void test_failsIfDelegateFails() {
+        IllegalStateException delegateException = new IllegalStateException();
+        doThrow(delegateException).when(delegate).before();
+
+        expectedException.expect(IllegalStateException.class);
+
+        resource.before();
+    }
+
+    @Test
+    public void test_failsOnSubsequentCalls() {
+        IllegalStateException delegateException = new IllegalStateException();
+        doThrow(delegateException).when(delegate).before();
+
+        try {
+            resource.before();
+        } catch (IllegalStateException e) {
+            assertThat(e, is(equalTo(delegateException)));
+        }
+
+        // but resource should remember the failure
+        try {
+            resource.before();
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), is(equalTo("Failing due to previous error")));
+            assertThat(e.getCause(), is(equalTo(delegateException)));
+        }
+
+        // make sure we only called the delegate once
+        verify(delegate, times(1)).before();
+    }
+
+    @Test
+    public void test_remembersFailureOfParallelRequests()
+            throws InterruptedException, TimeoutException, BrokenBarrierException {
+        CyclicBarrier delegateEntries = new CyclicBarrier(3);
+        CyclicBarrier failingDelegate = new CyclicBarrier(2);
+        CyclicBarrier successfulDelegate = new CyclicBarrier(2);
+
+        IllegalStateException delegateException = new IllegalStateException();
+
+        /* first invocation fails*/
+        Mockito.doAnswer((inv) -> { delegateEntries.await(); failingDelegate.await(); throw delegateException; })
+                // second invocation succeeds
+                .doAnswer((inv) -> { delegateEntries.await(); successfulDelegate.await(); return null; })
+                .when(delegate).before();
+
+        // run two parallel befores
+        new Thread(() -> { try { resource.before(); } catch (IllegalStateException e) { /* expected */ }  }).start();
+        new Thread(() -> { try { resource.before(); } catch (IllegalStateException e) { /* expected */ }  }).start();
+
+        // wait up to 100 ms until both invocations entered the delegate
+        delegateEntries.await(100, TimeUnit.MILLISECONDS);
+        // then release the failure first, ensuring it 'loses' the race should there be a race
+        failingDelegate.await();
+        // lastly release the success
+        successfulDelegate.await();
+
+        // and ensure any following calls still fail
+        expectedException.expect(IllegalStateException.class);
+
+        resource.before();
+    }
+}

--- a/junit-resource-poller/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/junit-resource-poller/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
At times it is reasonable to wait for a long (~minutes) time for resources
to become available - think large docker-composes on limited hardware.

This requires configuring the default poller with a fairly long timeout. Unfortunately
if you do that, and one of the resources is misconfigured and will never come up, you
will wait the entire long timeout for each test in your suite before aborting the entire
build. This can easily take you from a build taking ~10 minutes to over an hour.

The FailureCachingHttpPollingResource allows you to tolerate a long wait as long as the
resource becomes available eventually; but once you do time out, any subsequent tests will
fail eagerly instead of waiting the full timeout again.