### PR TITLE
Add java 9+ support

### DIFF
--- a/junit-resource-poller/src/test/java/com/palantir/junit/FailureCachingHttpPollingResourceTest.java
+++ b/junit-resource-poller/src/test/java/com/palantir/junit/FailureCachingHttpPollingResourceTest.java
@@ -31,11 +31,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
+@RunWith(MockitoJUnitRunner.class)
 public final class FailureCachingHttpPollingResourceTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -46,7 +48,6 @@ public final class FailureCachingHttpPollingResourceTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
         resource = new FailureCachingHttpPollingResource(delegate);
     }
 


### PR DESCRIPTION
OkHttpClient requires us to pass X509TrustManager separately since it can't rely on reflection to get that out of SSLSocketFactory in java 9