### PR TITLE
JUnit5 Support ResourcePoller#poll(PollableResource)

### DIFF
--- a/junit-resource-poller/src/main/java/com/palantir/junit/HttpPollingExtension.java
+++ b/junit-resource-poller/src/main/java/com/palantir/junit/HttpPollingExtension.java
@@ -16,11 +16,12 @@
 
 package com.palantir.junit;
 
+import java.util.Optional;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public final class HttpPollingExtension implements Extension, BeforeAllCallback {
+public final class HttpPollingExtension implements Extension, BeforeAllCallback, PollableResource {
     private final HttpPollingResource delegate;
 
     private HttpPollingExtension(HttpPollingResource delegate) {
@@ -34,6 +35,11 @@ public final class HttpPollingExtension implements Extension, BeforeAllCallback 
 
     public static HttpPollingExtension.Builder builder() {
         return new HttpPollingExtension.Builder();
+    }
+
+    @Override
+    public Optional<Exception> isReady() {
+        return delegate.isReady();
     }
 
     public static final class Builder extends HttpPollingBuilder<Builder> {


### PR DESCRIPTION
Internally, there's some code that does this:

```java
ResourcePoller.poll(5, 1000, HttpPollingResource.builder()
                .sslSocketFactory(SslSocketFactories.createSslSocketFactory(sslConfiguration))
                .x509TrustManager(sslTrustManager)
                .pollUrls(ImmutableList.of(healthUri))
                .numAttempts(300)
                .build());
```

I want to fully ban the `junit` jar from the compileClasspath, but can't because the new Extension doesn't implement the right interface